### PR TITLE
feat: 좀비 파드 로그 로키, 프롬테일 설정

### DIFF
--- a/ansible/roles/logging/manifests/loki-configmap.yaml
+++ b/ansible/roles/logging/manifests/loki-configmap.yaml
@@ -1,0 +1,33 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: loki-config
+  namespace: logging
+data:
+  loki.yaml: |
+    auth_enabled: false
+
+    server:
+      http_listen_port: 3100
+
+    common:
+      path_prefix: /loki
+      replication_factor: 1
+      ring:
+        kvstore:
+          store: inmemory
+      storage:
+        filesystem:
+          chunks_directory: /loki/chunks
+          rules_directory: /loki/rules
+
+    schema_config:
+      configs:
+        - from: 2024-01-01
+          store: tsdb
+          object_store: filesystem
+          schema: v11
+          index:
+            prefix: index_
+            period: 24h
+

--- a/ansible/roles/logging/manifests/loki-deployment.yaml
+++ b/ansible/roles/logging/manifests/loki-deployment.yaml
@@ -1,0 +1,33 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: loki
+  namespace: logging
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: loki
+  template:
+    metadata:
+      labels:
+        app: loki
+    spec:
+      containers:
+        - name: loki
+          image: grafana/loki:2.9.10
+          args:
+            - -config.file=/etc/loki/loki.yaml
+          ports:
+            - containerPort: 3100
+          volumeMounts:
+            - name: loki-config
+              mountPath: /etc/loki
+            - name: loki-data
+              mountPath: /loki
+      volumes:
+        - name: loki-config
+          configMap:
+            name: loki-config
+        - name: loki-data
+          emptyDir: {}                                                   

--- a/ansible/roles/logging/manifests/loki-service.yaml
+++ b/ansible/roles/logging/manifests/loki-service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: loki
+  namespace: logging
+spec:
+  selector:
+    app: loki
+  ports:
+    - name: http
+      port: 3100
+      targetPort: 3100
+

--- a/ansible/roles/logging/manifests/promtail-configmap.yaml
+++ b/ansible/roles/logging/manifests/promtail-configmap.yaml
@@ -1,0 +1,39 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: promtail-config
+  namespace: logging
+data:
+  promtail.yaml: |
+    server:
+      http_listen_port: 9080
+    positions:
+      filename: /run/promtail/positions.yaml
+    clients:
+      - url: http://loki.logging.svc.cluster.local:3100/loki/api/v1/push
+
+    scrape_configs:
+      - job_name: kubernetes-pods
+        kubernetes_sd_configs:
+          - role: pod
+        pipeline_stages:
+          - cri: {}
+        relabel_configs:
+          # 메타데이터 라벨링
+          - source_labels: [__meta_kubernetes_namespace]
+            target_label: namespace
+          - source_labels: [__meta_kubernetes_pod_name]
+            target_label: pod
+          - source_labels: [__meta_kubernetes_pod_container_name]
+            target_label: container
+
+          # 경로 설정
+          - action: replace
+            target_label: __path__
+            replacement: /var/log/pods/*/*/*.log
+
+          # 파드 로그
+          - source_labels: [__meta_kubernetes_pod_uid, __meta_kubernetes_pod_container_name]
+            separator: /
+            target_label: __path__
+            replacement: /var/log/pods/*$1/$2/*.log

--- a/ansible/roles/logging/manifests/promtail-daemonset.yaml
+++ b/ansible/roles/logging/manifests/promtail-daemonset.yaml
@@ -1,0 +1,51 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: promtail
+  namespace: logging
+spec:
+  selector:
+    matchLabels:
+      app: promtail
+  template:
+    metadata:
+      labels:
+        app: promtail
+    spec:
+      serviceAccountName: promtail
+      containers:
+      - name: promtail
+        image: grafana/promtail:latest
+        args:
+        - -config.file=/etc/promtail/promtail.yaml
+        env:
+        - name: HOSTNAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        volumeMounts:
+        - name: config
+          mountPath: /etc/promtail
+        - name: run
+          mountPath: /run/promtail
+        # [중요] 실제 로그 파일이 있는 경로 마운트
+        - name: pods
+          mountPath: /var/log/pods
+          readOnly: true
+        - name: docker
+          mountPath: /var/lib/docker/containers
+          readOnly: true
+      volumes:
+      - name: config
+        configMap:
+          name: promtail-config
+      - name: run
+        hostPath:
+          path: /run/promtail
+      # [중요] 호스트 노드의 실제 로그 경로 연결
+      - name: pods
+        hostPath:
+          path: /var/log/pods
+      - name: docker
+        hostPath:
+          path: /var/lib/docker/containers

--- a/ansible/roles/logging/manifests/promtail-rbac.yaml
+++ b/ansible/roles/logging/manifests/promtail-rbac.yaml
@@ -1,0 +1,28 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: promtail
+  namespace: logging
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: promtail-cluster-role
+rules:
+  - apiGroups: [""]
+    resources: ["pods", "nodes", "nodes/proxy", "services", "endpoints"]
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: promtail-cluster-role-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: promtail-cluster-role
+subjects:
+  - kind: ServiceAccount
+    name: promtail
+    namespace: logging
+

--- a/ansible/setup-logging.yml
+++ b/ansible/setup-logging.yml
@@ -1,0 +1,22 @@
+---
+- name: Deploy Logging Stack to Kind Cluster
+  hosts: localhost
+  connection: local
+  tasks:
+    - name: Ensure logging namespace exists
+      kubernetes.core.k8s:
+        name: logging
+        kind: Namespace
+        state: present
+
+    - name: Apply Kubernetes Manifests
+      kubernetes.core.k8s:
+        src: "{{ item }}"
+        state: present
+      loop:
+        - "./roles/logging/manifests/loki-configmap.yaml"
+        - "./roles/logging/manifests/loki-service.yaml"
+        - "./roles/logging/manifests/loki-deployment.yaml"
+        - "./roles/logging/manifests/promtail-configmap.yaml"
+        - "./roles/logging/manifests/promtail-daemonset.yaml"
+


### PR DESCRIPTION
## 작업내용

#### loki-configmap.yaml 
- 로그 저장소인 loki의 저장 주기, 압축 방식 등 내부 동작 설정
#### loki-deployment.yaml 
- loki를 클러스터에 배포, 로그 데이터를 담을 컨테이너 실행
#### loki-service.yaml : 
- promtail에 로그를 보낼 수 있도록 loki DNS 고정
#### promtail-configmap.yaml : 
- /var/log/pods 로그를 긁어서 loki로 보내는 규칙 설정
#### promtail-daemonset.yaml : 
- 모든 노드에 promtail을 실행시켜 로그파일 수집
#### promtail-rbac.yaml : 
- 각 파드 정보를 조회할 수 있는 권한 부여
#### setup-logging.yml : 
- manifests 순서대로 배포하도록 하는 플레이북 
---
## 스크린샷
<img width="1439" height="924" alt="스크린샷 2026-02-05 오후 2 13 13" src="https://github.com/user-attachments/assets/8bde3e67-b458-4833-b710-5ea2eaba494f" />