### PR TITLE
feat : filter labels 자동으로 설정되도록 프로비저닝 

### DIFF
--- a/terraform/grafana.tf
+++ b/terraform/grafana.tf
@@ -16,3 +16,58 @@ resource "grafana_data_source" "loki" {
 
   depends_on = [kind_cluster.default]
 }
+
+resource "grafana_dashboard" "example_monitor" {
+  config_json = jsonencode({
+    title = "loki monitor"
+    uid = "loki-monitor-001"
+    refresh = "10s"
+    schemaVersion = 39
+
+    # 상단 드롭다운 변수 설정
+    templating = {
+      list = [
+        {
+          name = "selected_pod"
+          type = "query"
+          label = "대상 파드 선택"
+          datasource = { type = "loki", uid = grafana_data_source.loki.uid }
+          
+          definition = "label_values({namespace=~\".+\"}, pod)"
+          query      = "label_values({namespace=~\".+\"}, pod)"
+
+          refresh = 2
+          includeAll = true
+          allValue = ".+"
+          multi = false
+
+          # loki-0으로 되도록 설정 
+          current = {
+            selected = true
+            text = "loki-0"
+            value = "loki-0"
+          }
+        }
+      ]
+    }
+
+    # 로그 출력 패널
+    panels = [
+      {
+        type = "logs"
+        title = "실시간 로그: $selected_pod"
+        gridPos = { h=20, w=24, x=0, y=0 }
+        datasource = { 
+          type = "loki", 
+          uid = "${grafana_data_source.loki.uid}"
+        }
+        targets = [
+          {
+            # 선택한 파드 라벨로 고정
+            expr = "{pod=~\"$selected_pod\"}"
+          }
+        ]
+      }
+    ]
+  })
+}


### PR DESCRIPTION
## 변경사항
- 기존 데이터소스 자동화 이후 익스플로어 창에서 filter labels를 일일히 설정하는 것에 대한 자동화 진행
- Explore 창에서는 프로비저닝이 불가하다고 생각하여 dashboard 자동화로 변경
- 현재는 loki monitor이라는 대시보드에 pod=loki-0로 고정
- 추후 좀비파드 탐색 시 파드 이름 수정 예정

### 참고사진
<img width="764" height="428" alt="스크린샷 2026-02-06 오후 3 15 10" src="https://github.com/user-attachments/assets/a31899db-d266-40e5-a709-fc8378481d66" />
